### PR TITLE
SilverStripe 4.11 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "silverstripe/framework": "~4.1",
     "silverstripe/cms": "~4.1",
-    "sheadawson/silverstripe-linkable": "^2.0",
+    "gorriecoe/silverstripe-link": "^1.0",
     "undefinedoffset/sortablegridfield": "^2.0"
   },
   "require-dev": {

--- a/src/model/BookmarkLink.php
+++ b/src/model/BookmarkLink.php
@@ -1,7 +1,7 @@
 <?php
 namespace NZTA\MemberBookmark\Models;
 
-use Sheadawson\Linkable\Models\Link;
+use gorriecoe\Link\Models\Link;
 use SilverStripe\Security\Member;
 use SilverStripe\Forms\FieldList;
 

--- a/src/model/GlobalBookmark.php
+++ b/src/model/GlobalBookmark.php
@@ -1,7 +1,7 @@
 <?php
 namespace NZTA\MemberBookmark\Models;
 
-use Sheadawson\Linkable\Models\Link;
+use gorriecoe\Link\Models\Link;
 use SilverStripe\Security\Group;
 use SilverStripe\Forms\ListboxField;
 use SilverStripe\Forms\FieldList;
@@ -44,7 +44,7 @@ class GlobalBookmark extends Link
      * Here we check if this GlobalBookmark has a
      * SortOrder value. If not we assign it one.
      */
-    protected function onBeforeWrite()
+    public function onBeforeWrite()
     {
         if (!$this->SortOrder) {
             $this->SortOrder = GlobalBookmark::get()->max('SortOrder') + 1;

--- a/src/model/GlobalBookmarkModelAdmin.php
+++ b/src/model/GlobalBookmarkModelAdmin.php
@@ -1,7 +1,7 @@
 <?php
 namespace NZTA\MemberBookmark\Models;
 
-use Sheadawson\Linkable\Models\Link;
+use gorriecoe\Link\Models\Link;
 use SilverStripe\Admin\ModelAdmin;
 use NZTA\MemberBookmark\Models\GlobalBookmark;
 use SilverStripe\Forms\GridField\GridField;


### PR DESCRIPTION
nzta/member-bookmarks 2.0.2 is not compatible with the latest version of the SilverStripe CMS.
I have replaced the root dependency "sheadawson/silverstripe-linkable" (which is no longer actively maintained) with gorriecoe/silverstripe-link.

sheadawson relies on embed/embed ^3 which conflicts with Silverstripe 4.11 requiring embed/embed ^4